### PR TITLE
Fix renderer exiting out for the first onBeforeRender

### DIFF
--- a/lib/Renderer.lua
+++ b/lib/Renderer.lua
@@ -96,18 +96,20 @@ function Renderer:step(dt)
 		local viewport = self._viewportMap[highlight]
 		local objectRef = viewport:getReference()
 
+		local beforeRenderResult
 		if self.onBeforeRenderImpl then
-			local beforeRenderResult = self.onBeforeRenderImpl(dt, objectRef.worldModel)
+			beforeRenderResult = self.onBeforeRenderImpl(dt, objectRef.worldModel)
 			if beforeRenderResult == false then
 				viewport.rbx.Visible = false
-				return
 			end
 		end
-		for worldPart, viewportPart in pairs(objectRef.map) do
-			self.onRenderImpl(dt, worldPart, viewportPart, highlight)
-		end
-		viewport.rbx.Visible = true
 
+		if beforeRenderResult ~= false then
+			for worldPart, viewportPart in pairs(objectRef.map) do
+				self.onRenderImpl(dt, worldPart, viewportPart, highlight)
+			end
+			viewport.rbx.Visible = true
+		end
 	end
 end
 


### PR DESCRIPTION
This fixes #6. The renderer will now keep looping over every item in the stack, and will skip the ones where onBeforeRender returns `false`.